### PR TITLE
Allow up to 7 digits for the shorturl ending

### DIFF
--- a/lib/short.js
+++ b/lib/short.js
@@ -1,24 +1,24 @@
 
-var mongoose = require("mongoose");
-var base = require("base-converter");
-
-var ShortURL = require(__dirname + "/../models/ShortURL.js");
+var mongoose = require("mongoose"),
+    base = require("base-converter"),
+    ShortURL = require(__dirname + "/../models/ShortURL.js");
 
 function hasher(URL) {
-  var id = Math.floor(Math.random() * (100000 - 9999999 + 1) + 9999999);
-  var hash = base.decTo62(id);
+  //Generates a 3 to 7 digit number
+  var id = Math.floor(Math.random() * 3500000000000) + 3845,
+      hash = base.decTo62(id);
   return hash;
-};
+}
 
-module.exports = short = function(){};
+module.exports = short = function () {};
 
-short.connect = function(mongodb) {
+short.connect = function (mongodb) {
   mongoose.connect(mongodb);
 };
 
-short.gen = function(URL, callback) {
+short.gen = function (URL, callback) {
   var hashedURL = hasher(URL);
-  ShortURL.checkExists(hashedURL, function(error, shortenedURLs) {
+  ShortURL.checkExists(hashedURL, function (error, shortenedURLs) {
     if (error) {
       callback(error, null);
     } else {
@@ -27,12 +27,12 @@ short.gen = function(URL, callback) {
           URL : URL,
           hash : hashedURL
         });
-        item.save(function(error, item) {
+        item.save(function (error, item) {
           if (error) {
             callback(error, null);
           } else {
             callback(null, item); 
-          };
+          }
         });
       } else {
         short.gen(URL, callback);
@@ -41,13 +41,13 @@ short.gen = function(URL, callback) {
   });
 };
 
-short.get = function(hash, callback) {
-  ShortURL.findByHash(hash, function(error, URL) {
+short.get = function (hash, callback) {
+  ShortURL.findByHash(hash, function (error, URL) {
     if (error) {
       callback(error, null);
     } else {
       callback(null, URL);
-    };
+    }
   });
 };
 


### PR DESCRIPTION
Update allows for ~ 3.5 trillion unique short urls compared to the 100k
previous ones.  Ensures it's at least a 3 digit ending, with a maximum
of 7 digits possible.
