### PR TITLE
Changed findByHash to use findOne

### DIFF
--- a/examples/basic/api.js
+++ b/examples/basic/api.js
@@ -35,7 +35,7 @@ short.generate(URL, function(error, shortURL) {
         // Base 62 Hash
         console.log('hash:', shortenedURLObject.hash);
         process.exit(0);
-      };
+      }
     });
   }
 });

--- a/lib/short.js
+++ b/lib/short.js
@@ -15,12 +15,12 @@ var mongoose = require('mongoose'),
 function hasher(URL){
   // 62
   var AUID = [],
-      CHARS = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'.split(''); 
+      CHARS = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'.split('');
   for (var i = 0; i < 6; i++) {
     AUID[i] = CHARS[Math.floor(Math.random()*62)];
-  };
+  }
   return AUID.join('');
-};
+}
 
 /*!
  @method connect
@@ -31,7 +31,7 @@ function connect(mongodb){
   mongoose.connect(mongodb);
   // expose connection object
   exports.connection = mongoose.connection;
-};
+}
 
 /*!
  @method generate
@@ -54,7 +54,7 @@ function generate(URL, callback){
       callback(null, item);
     }
   });
-};
+}
 
 /*!
  @method retrieve
@@ -66,13 +66,13 @@ function retrieve(hash, callback){
   ShortURL.findByHash(hash, function (error, shortenedURLObject) {
     if (error) {
       callback(error, null);
-    } else if (shortenedURLObject.length) {
-      callback(null, shortenedURLObject[0]);
+    } else if (shortenedURLObject) {
+      callback(null, shortenedURLObject);
     } else {
       callback(null, null);
     }
   });
-};
+}
 
 /*!
   Expose Yourself!

--- a/models/ShortURL.js
+++ b/models/ShortURL.js
@@ -28,12 +28,13 @@ var ShortURL = mongoose.model('ShortURL', ShortURLSchema);
 
 
 ShortURL.findByHash = function(hash, callback) {
-  ShortURL.find({ hash: hash }, function(error, URL) {
+  ShortURL.findOne({ hash: hash }, function(error, URL) {
+    console.log(URL);
     if (error) {
       callback(error, null);
     } else {
-      if (URL.length !== 0) {
-        var id = URL[0]._id;
+      if (URL) {
+        var id = URL._id;
         ShortURL.updateHitsById(id, function(error) {
           if (error) {
             callback(error, null);


### PR DESCRIPTION
Mongoose's findOne returns the first result and then stops searching.  Find builds
up an array that we don't need.  Should be slightly faster now, since it's no longer building an unnecessary array.
