### PR TITLE
Small fix for retrieve(hash, callback) throwing.

### DIFF
--- a/lib/short.js
+++ b/lib/short.js
@@ -81,7 +81,7 @@ var generate = exports.generate = function(URL, options, callback){
 var retrieve = exports.retrieve = function(hash, options, callback) {
   if (arguments.length === 2  && arguments[1] instanceof Function) {
     callback = arguments[1];
-    options = null;
+    options = {};
   } else if (arguments.length === 3  && arguments[1] instanceof Object && arguments[2] instanceof Function) {
   // options takes an optional object literal
   // right now it only supports an options.visitor argument


### PR DESCRIPTION
Without this, options needs to be specified otherwise it throws in ShortURL.findByHash.
