### PR TITLE
Removed an extra promise layer

### DIFF
--- a/lib/short.js
+++ b/lib/short.js
@@ -101,12 +101,5 @@ exports.hits = function(hash) {
  */
 
 exports.list = function() {
-  var promise = new Promise();
-  var listPromise = ShortURL.find({});
-  listPromise.then(function(ShortenedURLObjects) {
-    promise.resolve(ShortenedURLObjects);
-  }, function(error) {
-    promise.reject(error, true);
-  });
-  return promise;
+  return ShortURL.find({});
 };


### PR DESCRIPTION
ShortURL.find() already returns a promise, I don't understand the need to wrap it in a extra promise. But I might defenetly be wrong.

I'm note used to doing pull requests so be gentle :)
