### PR TITLE
Expose the hash as part of the api

### DIFF
--- a/lib/short.js
+++ b/lib/short.js
@@ -37,7 +37,9 @@ exports.generate = function(document) {
     , promise = new Promise()
     , generatedHash = ID.store(document.URL)
     , query = { URL : document.URL };
-  document['hash'] = generatedHash;
+  if (!document.hasOwnProperty('hash')) {
+    document['hash'] = generatedHash;
+  }
   document['data'] = (document.data) ? document.data : null;
   generatePromise = ShortURL.findOrCreate(query, document, {});
   generatePromise.then(function(ShortURLObject) {


### PR DESCRIPTION
This would allow a consumer of this api to attempt to specify the hash. If there is already an entry with that hash (but the urls do not match), it will fail and reject the promise.

```
generate({
    url: URL,
    hash: HASH
}) -> no problem
generate({
   url: URL,
   hash: HASH
}) -> still no problem because it matches the existing entry
generate({
    url: URL2,
    hash: HASH
}) -> failed with a duplicate entry mongoose error
```
