### PR TITLE
Only connects if current state is disconnected

### DIFF
--- a/lib/short.js
+++ b/lib/short.js
@@ -23,7 +23,9 @@ ID.configure({
  */
 
 exports.connect = function(mongodb) {
-  mongoose.connect(mongodb);
+  if (mongoose.connection.readyState === 0)
+    mongoose.connect(mongodb);
+
   exports.connection = mongoose.connection;
 };
 
@@ -62,7 +64,7 @@ exports.generate = function(document) {
 
 exports.retrieve = function(hash) {
   var promise = new Promise();
-  var query = { hash : hash } 
+  var query = { hash : hash }
     , update = { $inc: { hits: 1 } }
     , options = { multi: true };
   var retrievePromise = ShortURL.findOne(query);
@@ -86,7 +88,7 @@ exports.retrieve = function(hash) {
 
 exports.hits = function(hash) {
   var promise = new Promise();
-  var query = { hash : hash } 
+  var query = { hash : hash }
     , options = { multi: true };
   var retrievePromise = ShortURL.findOne(query);
   ShortURL.update(query, update, options, function(){ });


### PR DESCRIPTION
I found a bit of weird edge case, and wanted to call it to your attention. In the latest version, it seems if you are depending on short and the same version of mongoose that short uses, short and its dependent program will share the mongoose instance. 

The consequences of this are that if mongoose.connect is called before short.connect a "Error: Trying to open unclosed connection." is thrown. The solution to this would be to check mongoose's connection readyState to make sure it is disconnected before calling connect.

However I am not able to reproduce this issue in a linked version of the short dependency. I believe that b/c of how npm handles dependencies, if you are working with a local copy you get two instances of mongoose. So, I can't be sure this resolves the issue and I can only reproduce it with npm installed versions of the dependency. I understand hesitancy to pull in based on an unproven fix, but not sure what else to do other than pushing up a clone project to npm to try to reproduce. Let me know how you'd like to handle it.

This MIGHT be an environment quirk on my end: 
Im running node v0.10.35, npm 1.4.28, OS X 10.10.3 