### PR TITLE
Fix bug with missing update var & unnecessary update.

### DIFF
--- a/lib/short.js
+++ b/lib/short.js
@@ -91,7 +91,6 @@ exports.hits = function(hash) {
   var query = { hash : hash }
     , options = { multi: true };
   var retrievePromise = ShortURL.findOne(query);
-  ShortURL.update(query, update, options, function(){ });
   retrievePromise.then(function(ShortURLObject) {
     if (ShortURLObject && ShortURLObject !== null) {
       promise.resolve(ShortURLObject.hits);


### PR DESCRIPTION
1.  the 'update' var (an object normally with model changes) does not exist in this hits method.
2.  It doesn't seem this is necessary here.