### PR TITLE
fix to make the URL and data keys optional during update

### DIFF
--- a/lib/short.js
+++ b/lib/short.js
@@ -90,8 +90,12 @@ exports.retrieve = function(hash) {
 exports.update = function(hash, updates) {
   var promise = new Promise();
   ShortURL.findOne({hash: hash}, function(err, doc) {
-    doc.URL = updates.URL;
-    doc.data = extend(doc.data, updates.data);
+    if (updates.URL) {
+      doc.URL = updates.URL;
+    }
+    if (updates.data) {
+      doc.data = extend(doc.data, updates.data);
+    }
     doc.save(function(err, updatedObj, numAffected) {
       if (err) {
         promise.reject(new Error('MongoDB - Cannot save updates'), true);

--- a/lib/short.js
+++ b/lib/short.js
@@ -95,6 +95,7 @@ exports.update = function(hash, updates) {
     }
     if (updates.data) {
       doc.data = extend(doc.data, updates.data);
+      doc.markModified('data'); //Required by mongoose, as data is of Mixed type
     }
     doc.save(function(err, updatedObj, numAffected) {
       if (err) {


### PR DESCRIPTION
just a quick fix, a potential bug in the previous case was that the URL would become undefined if the `URL` parameter wasn't set in the updates parameter, during update