### PR TITLE
add support to use mongoose with authenticated databases

### DIFF
--- a/lib/short.js
+++ b/lib/short.js
@@ -20,11 +20,13 @@ ID.configure({
 /**
  * @method connect
  * @param {String} mongdb Mongo DB String to connect to
+ * @param {Object} [options]
+ * @param {Function} [callback]
  */
 
-exports.connect = function(mongodb) {
+exports.connect = function() {
   if (mongoose.connection.readyState === 0)
-    mongoose.connect(mongodb);
+    mongoose.connect(arguments[0], arguments[1], arguments[2]);
 
   exports.connection = mongoose.connection;
 };

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies":{
     "node-promise":"0.5.8",
-    "mongoose":"4.0.6",
+    "mongoose":"^5.0.5",
     "short-id":"0.1.0-1"
   },
   "devDependencies":{

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -21,7 +21,7 @@ var options = {
 //     pass: 'test'
 };
 
-short.connect('mongodb://localhost/short',options);
+short.connect('mongodb://localhost:27017/short',options);
 
 /**
  * @description add suites to vows

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -14,7 +14,14 @@ mongoose.set('debug', true);
  * @description connect to mongodb
  */
 
-short.connect('mongodb://localhost/short');
+var options = {
+
+    /* uncomment this if using auth */
+//     user: 'test',
+//     pass: 'test'
+};
+
+short.connect('mongodb://localhost/short',options);
 
 /**
  * @description add suites to vows


### PR DESCRIPTION
authentication options can be passed through the uri, but I find it cleaner to do it through the options object.